### PR TITLE
Adding REST endpoints for getting meeting and user images

### DIFF
--- a/backend/src/core/image.service.ts
+++ b/backend/src/core/image.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { existsSync, unlinkSync, writeFileSync,  } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync,  } from 'fs';
 
 @Injectable()
 export class ImageService {
@@ -16,6 +16,20 @@ export class ImageService {
         } catch (err) {
             return false;
         }
+    }
+
+    read(name: string, folder: string): string {
+        let img_data: string;
+        try {
+            img_data = readFileSync(`${folder}/${name}.jpg`, {
+                encoding: "base64",
+                flag: "r+"
+            });
+        } catch(err) {
+            throw err;
+        }
+
+        return img_data;
     }
 
     delete(name: string, folder: string): boolean {

--- a/backend/src/meetings/meeting/meeting.controller.ts
+++ b/backend/src/meetings/meeting/meeting.controller.ts
@@ -11,6 +11,7 @@ import { MeetingEntity } from '../entities/meeting.entity';
 import { Repository } from 'typeorm';
 import { MeetingDto } from '../dto/meeting.dto';
 import { CalendarService } from '../calendar.service';
+import { join } from 'path';
 
 @Controller('meeting')
 export class MeetingController {
@@ -45,6 +46,21 @@ export class MeetingController {
   @Get(':mid/calendar')
   async getCalendarForMeeting(@Req() request: EvendemyRequest, @Param('mid') mid: string) {
     return this.meetingsService.findOne(+mid).then(m => this.calendarService.createICAL(m));
+  }
+
+  @Get(":mid/image")
+  async getPicture(@Req() req: EvendemyRequest, @Param('mid') mid: String){
+    const meeting = await this.meetingsService.findOne(+mid);
+
+    if(meeting.images && meeting.images.length > 0) {
+      try{
+        return this.imageService.read(meeting.images[0],this.path)
+      } catch (err) {
+        throw new HttpException("No image found for meeting", HttpStatus.NOT_FOUND);
+      }
+    } else {
+      throw new HttpException("No image found for meeting", HttpStatus.NOT_FOUND);
+    }
   }
 
   @Post(":mid/image")

--- a/backend/src/users/user/user.controller.ts
+++ b/backend/src/users/user/user.controller.ts
@@ -22,7 +22,7 @@ export class UserController {
     async getUserImage(@Req() req: EvendemyRequest, @Param('username') username: string) {
         var user = await this.usersService.findOne(username);
         if(user.avatar) {
-            var user_image_data = this.imageService.read(req.user.username,this.path);
+            var user_image_data = this.imageService.read(username,this.path);
             return user_image_data;
         }
         throw new HttpException("User has no Avatar", HttpStatus.NOT_FOUND);

--- a/backend/src/users/user/user.controller.ts
+++ b/backend/src/users/user/user.controller.ts
@@ -17,6 +17,16 @@ export class UserController {
     getOneUser(@Param('username') username: string) {
         return this.usersService.findOne(username);
     }
+    
+    @Get(':username/image')
+    async getUserImage(@Req() req: EvendemyRequest, @Param('username') username: string) {
+        var user = await this.usersService.findOne(username);
+        if(user.avatar) {
+            var user_image_data = this.imageService.read(req.user.username,this.path);
+            return user_image_data;
+        }
+        throw new HttpException("User has no Avatar", HttpStatus.NOT_FOUND);
+    }
 
     @Post(':username/image')
     async saveUserImage(@Req() req: EvendemyRequest, @Param('username') username: string) {

--- a/backend/src/users/user/user.controller.ts
+++ b/backend/src/users/user/user.controller.ts
@@ -21,7 +21,7 @@ export class UserController {
     @Get(':username/image')
     async getUserImage(@Req() req: EvendemyRequest, @Param('username') username: string) {
         var user = await this.usersService.findOne(username);
-        if(user.avatar) {
+        if(user && user.avatar) {
             var user_image_data = this.imageService.read(username,this.path);
             return user_image_data;
         }


### PR DESCRIPTION
## Changes
- Added "/user/{username}/image" get request to [backend/src/users/user/user.controller.ts](https://github.com/if-loop69420/evendemy/blob/PictureRestEndpoint/backend/src/users/user/user.controller.ts) for getting user images with the supplied username
- Added "/{meeting_id}/image" get reqzest to [backend/src/meetings/meeting/meeting.controller.ts](https://github.com/if-loop69420/evendemy/blob/PictureRestEndpoint/backend/src/meetings/meeting/meeting.controller.ts) for getting meeting images with a supplied meeting id.
- Added a read function to [backend/src/core/image.service.ts](https://github.com/if-loop69420/evendemy/blob/PictureRestEndpoint/backend/src/core/image.service.ts) for reading the images needed in the get requests supplied above.

## How to test before merging
- [ ] Run backend with ```cd backend && npm run start```
- [ ] Run webapp with ```cd webapp && npm run start```
- [ ] Open swaggerUI http://localhost:3000
- [ ] Add an image for a user with a username of your choosing to webapp/src/assets/user_images/ 
- [ ] Send a get request for the username of your image
- [ ] Receive a b64 encoded image.
- [ ] If you decode it, or supply it as a source to an html image tag you should see your image

## Kind regards, Jeremy Sztavinovszki